### PR TITLE
add wasmName in XAppletReq

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -88,7 +88,7 @@ upload wasm script
 export PROJECTID=${project_id}
 export PROJECTNAME=${project_name}
 export WASMFILE=_examples/log/log.wasm
-http --form post :8888/srv-applet-mgr/v0/applet/$PROJECTID file@$WASMFILE info='{"appletName":"log","strategies":[{"eventType":"DEFAULT","handler":"start"}]}' -A bearer -a $TOK
+http --form post :8888/srv-applet-mgr/v0/applet/$PROJECTID file@$WASMFILE info='{"appletName":"log","wasmName":"log.wasm","strategies":[{"eventType":"DEFAULT","handler":"start"}]}' -A bearer -a $TOK
 ```
 
 output like

--- a/pkg/modules/resource/file_header.go
+++ b/pkg/modules/resource/file_header.go
@@ -19,7 +19,7 @@ import (
 
 var reserve = int64(100 * 1024 * 1024)
 
-func Upload(ctx context.Context, f *multipart.FileHeader, id string) (root, fullName, fileName, sum string, err error) {
+func Upload(ctx context.Context, f *multipart.FileHeader, id string) (root, fullName, sum string, err error) {
 	l := types.MustLoggerFromContext(ctx)
 	conf := types.MustUploadConfigFromContext(ctx)
 	var (
@@ -33,7 +33,6 @@ func Upload(ctx context.Context, f *multipart.FileHeader, id string) (root, full
 
 	root = filepath.Join(conf.Root, id)
 	fullName = filepath.Join(conf.Root, id, f.Filename)
-	fileName = f.Filename
 
 	if !IsDirExists(root) {
 		if err = os.MkdirAll(root, 0777); err != nil {

--- a/pkg/modules/resource/resource.go
+++ b/pkg/modules/resource/resource.go
@@ -14,12 +14,7 @@ import (
 	"github.com/machinefi/w3bstream/pkg/types"
 )
 
-type Info struct {
-	models.Resource
-	ResourceName string
-}
-
-func FetchOrCreateResource(ctx context.Context, f *multipart.FileHeader) (*Info, error) {
+func FetchOrCreateResource(ctx context.Context, f *multipart.FileHeader) (*models.Resource, error) {
 	d := types.MustDBExecutorFromContext(ctx)
 	l := types.MustLoggerFromContext(ctx)
 	idg := confid.MustSFIDGeneratorFromContext(ctx)
@@ -27,7 +22,7 @@ func FetchOrCreateResource(ctx context.Context, f *multipart.FileHeader) (*Info,
 	_, l = l.Start(ctx, "FetchOrCreateResource")
 	defer l.End()
 
-	_, fullName, fileName, md5, err := Upload(ctx, f, idg.MustGenSFID().String())
+	_, fullName, md5, err := Upload(ctx, f, idg.MustGenSFID().String())
 	if err != nil {
 		l.Error(err)
 		return nil, status.UploadFileFailed.StatusErr().WithDesc(err.Error())
@@ -47,5 +42,5 @@ func FetchOrCreateResource(ctx context.Context, f *multipart.FileHeader) (*Info,
 		l.Info("wasm resource created")
 	}
 	l.Info("get wasm resource from db")
-	return &Info{Resource: *m, ResourceName: fileName}, err
+	return m, err
 }


### PR DESCRIPTION
In order to fix the loss of the name attribute when the frontend transmits the blob file, add  wasmName parameter in CreateAppletReq and UpdateAppletReq