### PR TITLE
fix Dockefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /w3bstream
 
 EXPOSE 8888
 
-COPY --from=build-go /w3bstream/cmd/srv-applet-mgr/srv-applet-mgr /w3bstream/srv-applet-mgr
+COPY --from=build-go /w3bstream/cmd/srv-applet-mgr /w3bstream/srv-applet-mgr
 
 COPY cmd/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod a+x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Build fails with 
```
Step 8/11 : COPY --from=build-go /w3bstream/cmd/srv-applet-mgr/srv-applet-mgr /w3bstream/srv-applet-mgr
COPY failed: stat w3bstream/cmd/srv-applet-mgr/srv-applet-mgr: file does not exist
make: *** [Makefile:54: build_backend_image] Error 1
``` 

This fix fixes the error