### PR TITLE
refactor runtime and export functions

### DIFF
--- a/pkg/modules/vm/wasmtime/instance.go
+++ b/pkg/modules/vm/wasmtime/instance.go
@@ -23,14 +23,17 @@ func NewInstanceByCode(ctx context.Context, id types.SFID, code []byte) (i *Inst
 	defer l.End()
 
 	res := mapx.New[uint32, []byte]()
-
-	ef, err := NewExportFuncs(wasm.WithRuntimeResource(ctx, res), code)
+	rt := NewRuntime()
+	lk, err := NewExportFuncs(wasm.WithRuntimeResource(ctx, res), rt)
 	if err != nil {
+		return nil, err
+	}
+	if err := rt.Initiate(lk, code); err != nil {
 		return nil, err
 	}
 
 	return &Instance{
-		rt:       ef.rt,
+		rt:       rt,
 		id:       id,
 		state:    enums.INSTANCE_STATE__CREATED,
 		res:      res,


### PR DESCRIPTION
1. introduce `Import func(module, name string, f interface{}) error`
2. new `Runtime` in instance.go
3. introduce function `Initiate` to link `Runtime` and `ExportFuncs`
4. refactor `RunTime`
5. catch some errors