### PR TITLE
[wasm] Table isolation

### DIFF
--- a/pkg/depends/schema/schema.go
+++ b/pkg/depends/schema/schema.go
@@ -20,7 +20,7 @@ func NewSchema(name string) *Schema {
 }
 
 type Schema struct {
-	Name   string   `json:"-"`
+	Name   string   `json:"name,omitempty"`
 	Tables []*Table `json:"tables"`
 
 	*mapx.Map[string, *Table] `json:"-"`

--- a/pkg/depends/schema/schema_test.go
+++ b/pkg/depends/schema/schema_test.go
@@ -54,6 +54,7 @@ func ExampleSchema() {
 
 	// Output:
 	// {
+	//   "name": "demo",
 	//   "tables": [
 	//     {
 	//       "name": "tbl",
@@ -90,12 +91,13 @@ func ExampleSchema() {
 	//     }
 	//   ]
 	// }
-	// {"tables":[{"name":"tbl","desc":"test table","cols":[{"name":"f_username","constrains":{"datatype":"TEXT","length":255,"desc":"user name"}},{"name":"f_gender","constrains":{"datatype":"UINT8","length":255,"desc":"user name"}}],"keys":[{"name":"ui_username","isUnique":true,"columnNames":["f_username"]}],"withSoftDeletion":true,"withPrimaryKey":true}]}
+	// {"name":"demo","tables":[{"name":"tbl","desc":"test table","cols":[{"name":"f_username","constrains":{"datatype":"TEXT","length":255,"desc":"user name"}},{"name":"f_gender","constrains":{"datatype":"UINT8","length":255,"desc":"user name"}}],"keys":[{"name":"ui_username","isUnique":true,"columnNames":["f_username"]}],"withSoftDeletion":true,"withPrimaryKey":true}]}
 }
 
 var (
 	Schema       *schema.Schema
 	SchemaConfig = []byte(`{
+  "name": "demo",
   "tables": [
     {
       "name": "tbl",

--- a/pkg/modules/project/project_config.go
+++ b/pkg/modules/project/project_config.go
@@ -36,16 +36,16 @@ func CreateProjectSchema(ctx context.Context, schema *wasm.Schema) error {
 	_, l = l.Start(ctx, "CreateProjectSchema")
 	defer l.End()
 
-	if err := config.CreateConfig(ctx, prj.ProjectID, schema); err != nil {
-		l.Error(err)
-		return err
-	}
 	schema.WithName(prj.Name)
 	if err := schema.Init(); err != nil {
 		l.Error(err)
 		return status.InternalServerError.StatusErr().
 			WithDesc(fmt.Sprintf("init schema failed: [project:%s] [err:%v]",
 				prj.Name, err))
+	}
+	if err := config.CreateConfig(ctx, prj.ProjectID, schema); err != nil {
+		l.Error(err)
+		return err
 	}
 
 	wasmdb := types.MustWasmDBExecutorFromContext(ctx)

--- a/pkg/modules/vm/wasmtime/instance_exports.go
+++ b/pkg/modules/vm/wasmtime/instance_exports.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	conflog "github.com/machinefi/w3bstream/pkg/depends/conf/log"
-	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx"
 	"github.com/machinefi/w3bstream/pkg/depends/x/mapx"
 	"github.com/machinefi/w3bstream/pkg/types/wasm"
 )
@@ -33,7 +32,7 @@ type (
 		res *mapx.Map[uint32, []byte]
 		env *wasm.Env
 		kvs wasm.KVStore
-		db  sqlx.DBExecutor
+		db  wasm.SQLStore
 		log conflog.Logger
 		cl  *wasm.ChainClient
 	}
@@ -46,7 +45,7 @@ func NewExportFuncs(ctx context.Context, rt *Runtime) (*ExportFuncs, error) {
 		log: wasm.MustLoggerFromContext(ctx),
 	}
 	ef.cl, _ = wasm.ChainClientFromContext(ctx)
-	ef.db, _ = wasm.DBExecutorFromContext(ctx)
+	ef.db, _ = wasm.SQLStoreFromContext(ctx)
 	ef.env, _ = wasm.EnvFromContext(ctx)
 	ef.rt = rt
 

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -74,22 +74,22 @@ func MustMonitorDBExecutorFromContext(ctx context.Context) sqlx.DBExecutor {
 	return v
 }
 
-func WithWasmDBExecutor(ctx context.Context, v sqlx.DBExecutor) context.Context {
+func WithWasmDBExecutor(ctx context.Context, v postgres.Endpoint) context.Context {
 	return contextx.WithValue(ctx, CtxWasmDBExecutor{}, v)
 }
 
-func WithWasmDBExecutorContext(v sqlx.DBExecutor) contextx.WithContext {
+func WithWasmDBExecutorContext(v *postgres.Endpoint) contextx.WithContext {
 	return func(ctx context.Context) context.Context {
 		return contextx.WithValue(ctx, CtxWasmDBExecutor{}, v)
 	}
 }
 
-func WasmDBExecutorFromContext(ctx context.Context) (sqlx.DBExecutor, bool) {
-	v, ok := ctx.Value(CtxWasmDBExecutor{}).(sqlx.DBExecutor)
+func WasmDBExecutorFromContext(ctx context.Context) (*postgres.Endpoint, bool) {
+	v, ok := ctx.Value(CtxWasmDBExecutor{}).(*postgres.Endpoint)
 	return v, ok
 }
 
-func MustWasmDBExecutorFromContext(ctx context.Context) sqlx.DBExecutor {
+func MustWasmDBExecutorFromContext(ctx context.Context) *postgres.Endpoint {
 	v, ok := WasmDBExecutorFromContext(ctx)
 	must.BeTrue(ok)
 	return v

--- a/pkg/types/wasm/context.go
+++ b/pkg/types/wasm/context.go
@@ -4,14 +4,13 @@ import (
 	"context"
 
 	"github.com/machinefi/w3bstream/pkg/depends/conf/log"
-	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx"
 	"github.com/machinefi/w3bstream/pkg/depends/x/contextx"
 	"github.com/machinefi/w3bstream/pkg/depends/x/mapx"
 	"github.com/machinefi/w3bstream/pkg/depends/x/misc/must"
 )
 
 type (
-	CtxDBExecutor      struct{}
+	CtxSQLStore        struct{}
 	CtxKVStore         struct{}
 	CtxLogger          struct{}
 	CtxEnv             struct{}
@@ -21,23 +20,23 @@ type (
 	CtxRuntimeResource struct{}
 )
 
-func WithDBExecutor(ctx context.Context, v sqlx.DBExecutor) context.Context {
-	return contextx.WithValue(ctx, CtxDBExecutor{}, v)
+func WithSQLStore(ctx context.Context, v SQLStore) context.Context {
+	return contextx.WithValue(ctx, CtxSQLStore{}, v)
 }
 
-func WithDBExecutorContext(v sqlx.DBExecutor) contextx.WithContext {
+func WithSQLStoreContext(v SQLStore) contextx.WithContext {
 	return func(ctx context.Context) context.Context {
-		return contextx.WithValue(ctx, CtxDBExecutor{}, v)
+		return contextx.WithValue(ctx, CtxSQLStore{}, v)
 	}
 }
 
-func DBExecutorFromContext(ctx context.Context) (sqlx.DBExecutor, bool) {
-	v, ok := ctx.Value(CtxDBExecutor{}).(sqlx.DBExecutor)
+func SQLStoreFromContext(ctx context.Context) (SQLStore, bool) {
+	v, ok := ctx.Value(CtxSQLStore{}).(SQLStore)
 	return v, ok
 }
 
-func MustDBExecutorFromContext(ctx context.Context) sqlx.DBExecutor {
-	v, ok := DBExecutorFromContext(ctx)
+func MustSQLStoreFromContext(ctx context.Context) SQLStore {
+	v, ok := SQLStoreFromContext(ctx)
 	must.BeTrue(ok)
 	return v
 }

--- a/pkg/types/wasm/instance.go
+++ b/pkg/types/wasm/instance.go
@@ -3,6 +3,7 @@ package wasm
 import (
 	"context"
 
+	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx"
 	"github.com/machinefi/w3bstream/pkg/enums"
 )
 
@@ -45,6 +46,10 @@ type EventConsumer interface {
 type KVStore interface {
 	Get(string) ([]byte, error)
 	Set(key string, value []byte) error
+}
+
+type SQLStore interface {
+	sqlx.SqlExecutor
 }
 
 type ContextHandler interface {

--- a/pkg/types/wasm/wasm_config_database.go
+++ b/pkg/types/wasm/wasm_config_database.go
@@ -2,18 +2,42 @@ package wasm
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 
+	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx"
 	"github.com/machinefi/w3bstream/pkg/depends/schema"
 	"github.com/machinefi/w3bstream/pkg/enums"
 	"github.com/machinefi/w3bstream/pkg/types"
 )
 
-type Schema struct{ schema.Schema }
+type Schema struct {
+	schema.Schema
+	db sqlx.DBExecutor
+}
 
 func (s *Schema) ConfigType() enums.ConfigType {
 	return enums.CONFIG_TYPE__PROJECT_SCHEMA
 }
 
 func (s *Schema) WithContext(ctx context.Context) context.Context {
-	return WithDBExecutor(ctx, s.DBExecutor(types.MustWasmDBExecutorFromContext(ctx)))
+	db, err := types.MustWasmDBExecutorFromContext(ctx).NewConnection()
+	if err != nil {
+		panic(err)
+	}
+	// limit the scope of sql to the schema
+	fmt.Println("schema name", s.Name)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", s.Name)); err != nil {
+		panic(err)
+	}
+	s.db = db
+	return WithSQLStore(ctx, s)
+}
+
+func (s *Schema) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return s.db.ExecContext(ctx, query, args...)
+}
+
+func (s *Schema) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return s.db.QueryContext(ctx, query, args...)
 }

--- a/pkg/types/wasm/wasm_config_database.go
+++ b/pkg/types/wasm/wasm_config_database.go
@@ -26,7 +26,6 @@ func (s *Schema) WithContext(ctx context.Context) context.Context {
 		panic(err)
 	}
 	// limit the scope of sql to the schema
-	fmt.Println("schema name", s.Name)
 	if _, err := db.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", s.Name)); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
PG's [search_path](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH) is used to quarantine SQLs which are executed on different schemas of the same database