### PR TITLE
[bugfix]fix schema name && create project error

### DIFF
--- a/cmd/srv-applet-mgr/apis/middleware/project_provider.go
+++ b/cmd/srv-applet-mgr/apis/middleware/project_provider.go
@@ -28,7 +28,7 @@ func ProjectNameModifier(ctx context.Context) (prefix string, err error) {
 		return "", status.CurrentAccountAbsence
 	}
 
-	prefix = "aid_+" + ca.AccountID.String() + "_"
+	prefix = "aid_" + ca.AccountID.String() + "_"
 	aci, err := account_identity.GetBySFIDAndType(
 		ctx,
 		ca.AccountID,
@@ -36,6 +36,8 @@ func ProjectNameModifier(ctx context.Context) (prefix string, err error) {
 	)
 	if err == nil {
 		prefix = "eth_" + aci.IdentityID + "_"
+	} else if err.(status.Error).Code() == status.AccountIdentityNotFound.Code() {
+		return prefix, nil
 	}
 	return
 }


### PR DESCRIPTION
Creating a project with admin user fails. Because 
1. The schema name of the project contains special characters such as "+".
2. The admin user will return a `status.AccountIdentityNotFound` error, which needs to be caught.