### PR TITLE
make the release workflow run only on stable build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:


### PR DESCRIPTION
To save the time of the ci and make the latest release build make more sense.