### PR TITLE
fix(applet): correct wasm resource filename

### DIFF
--- a/pkg/modules/applet/applet.go
+++ b/pkg/modules/applet/applet.go
@@ -141,7 +141,11 @@ func Create(ctx context.Context, r *CreateReq) (*CreateRsp, error) {
 		err error
 	)
 
-	res, raw, err = resource.Create(ctx, acc.AccountID, r.File, r.AppletName, r.WasmMd5)
+	filename := r.WasmName
+	if filename == "" {
+		filename = r.AppletName + ".wasm"
+	}
+	res, raw, err = resource.Create(ctx, acc.AccountID, r.File, filename, r.WasmMd5)
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +218,9 @@ func Update(ctx context.Context, r *UpdateReq) (*UpdateRsp, error) {
 	if r.File != nil {
 		acc := types.MustAccountFromContext(ctx)
 		filename, md5 := r.Info.WasmName, r.Info.WasmMd5
+		if filename == "" {
+			filename = r.AppletName + ".wasm"
+		}
 		res, raw, err = resource.Create(ctx, acc.AccountID, r.File, filename, md5)
 	}
 

--- a/pkg/modules/applet/applet_models.go
+++ b/pkg/modules/applet/applet_models.go
@@ -66,7 +66,7 @@ type ListDetailRsp struct {
 }
 
 type Info struct {
-	AppletName string                `json:"appletName,omitempty"`
+	AppletName string                `json:"appletName"`
 	Deploy     datatypes.Bool        `json:"start"` // Deploy and start vm after created
 	WasmName   string                `json:"wasmName,omitempty"`
 	WasmMd5    string                `json:"wasmMd5,omitempty"`


### PR DESCRIPTION
Make `applet.CreateReq.Info.AppletName` required, resource module uses `info.WasmName` as filename, if it is empty filename is `info.AppletName+'.wasm'`