### PR TITLE
Fix vm panic under high loads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/bytecodealliance/wasmtime-go v1.0.0
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	// github.com/ethereum/go-ethereum v1.11.4
 	github.com/fatih/color v1.13.0
@@ -41,12 +40,12 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go v1.44.245
+	github.com/bytecodealliance/wasmtime-go/v8 v8.0.0
 	github.com/ethereum/go-ethereum v1.10.15
 	github.com/go-co-op/gocron v1.22.0
 	github.com/minio/minio-go/v7 v7.0.52
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spruceid/siwe-go v0.2.0
-	google.golang.org/grpc v1.41.0
 )
 
 require (
@@ -94,7 +93,6 @@ require (
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
-github.com/bytecodealliance/wasmtime-go v1.0.0 h1:9u9gqaUiaJeN5IoD1L7egD8atOnTGyJcNp8BhkL9cUU=
-github.com/bytecodealliance/wasmtime-go v1.0.0/go.mod h1:jjlqQbWUfVSbehpErw3UoWFndBXRRMvfikYH6KsCwOg=
+github.com/bytecodealliance/wasmtime-go/v8 v8.0.0 h1:jP4sqm2PHgm3+eQ50zCoCdIyQFkIL/Rtkw6TT8OYPFI=
+github.com/bytecodealliance/wasmtime-go/v8 v8.0.0/go.mod h1:tgazNLU7xSC2gfRAM8L4WyE+dgs5yp9FF5/tGebEQyM=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
@@ -942,7 +942,6 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 h1:PDIOdWxZ8eRizhKa1AAvY53xsvLB1cWorMjslvY3VA8=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -958,7 +957,6 @@ google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.41.0 h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=
 google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/modules/event/event.go
+++ b/pkg/modules/event/event.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"time"
 
-	"github.com/machinefi/w3bstream/pkg/depends/x/misc/timer"
 	"github.com/machinefi/w3bstream/pkg/errors/status"
 	"github.com/machinefi/w3bstream/pkg/models"
 	"github.com/machinefi/w3bstream/pkg/modules/strategy"
@@ -73,21 +71,14 @@ func OnEvent(ctx context.Context, data []byte) (ret []*Result) {
 		wg.Add(1)
 		go func(v *types.StrategyResult) {
 			defer wg.Done()
-
-			cost := timer.Start()
-			select {
-			case <-time.After(time.Second * 5):
-			default:
-				rv := ins.HandleEvent(ctx, v.Handler, v.EventType, data)
-				results <- &Result{
-					AppletName:  v.AppletName,
-					InstanceID:  v.InstanceID,
-					Handler:     v.Handler,
-					ReturnValue: nil,
-					ReturnCode:  int(rv.Code),
-					Error:       rv.ErrMsg,
-				}
-				l.WithValues("cst", cost().Milliseconds()).Info("")
+			rv := ins.HandleEvent(ctx, v.Handler, v.EventType, data)
+			results <- &Result{
+				AppletName:  v.AppletName,
+				InstanceID:  v.InstanceID,
+				Handler:     v.Handler,
+				ReturnValue: nil,
+				ReturnCode:  int(rv.Code),
+				Error:       rv.ErrMsg,
 			}
 		}(v)
 	}

--- a/pkg/modules/vm/wasmtime/instance.go
+++ b/pkg/modules/vm/wasmtime/instance.go
@@ -1,15 +1,15 @@
 package wasmtime
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
+	"fmt"
 	"time"
 
-	"github.com/bytecodealliance/wasmtime-go"
+	"github.com/bytecodealliance/wasmtime-go/v8"
 	"github.com/google/uuid"
 
 	"github.com/machinefi/w3bstream/pkg/depends/conf/log"
+	conflog "github.com/machinefi/w3bstream/pkg/depends/conf/log"
 	"github.com/machinefi/w3bstream/pkg/depends/x/contextx"
 	"github.com/machinefi/w3bstream/pkg/depends/x/mapx"
 	"github.com/machinefi/w3bstream/pkg/enums"
@@ -18,7 +18,14 @@ import (
 	"github.com/machinefi/w3bstream/pkg/types/wasm"
 )
 
+const (
+	maxUint           = ^uint32(0)
+	maxInt            = int(maxUint >> 1)
+	maxMsgPerInstance = 5000
+)
+
 type Instance struct {
+	ctx      context.Context
 	id       types.SFID
 	rt       *Runtime
 	state    wasm.InstanceState
@@ -26,6 +33,7 @@ type Instance struct {
 	evs      *mapx.Map[uint32, []byte]
 	handlers map[string]*wasmtime.Func
 	kvs      wasm.KVStore
+	msgQueue chan *Task
 }
 
 func NewInstanceByCode(ctx context.Context, id types.SFID, code []byte, st enums.InstanceState) (i *Instance, err error) {
@@ -48,7 +56,8 @@ func NewInstanceByCode(ctx context.Context, id types.SFID, code []byte, st enums
 		return nil, err
 	}
 
-	return &Instance{
+	ins := &Instance{
+		ctx:      ctx,
 		rt:       rt,
 		id:       id,
 		state:    st,
@@ -56,7 +65,12 @@ func NewInstanceByCode(ctx context.Context, id types.SFID, code []byte, st enums
 		evs:      evs,
 		handlers: make(map[string]*wasmtime.Func),
 		kvs:      wasm.MustKVStoreFromContext(ctx),
-	}, nil
+		msgQueue: make(chan *Task, maxMsgPerInstance),
+	}
+
+	go ins.queueWorker()
+
+	return ins, nil
 }
 
 var _ wasm.Instance = (*Instance)(nil)
@@ -86,18 +100,49 @@ func (i *Instance) HandleEvent(ctx context.Context, fn, eventType string, data [
 		}
 	}
 
-	t := NewTask(i, fn, eventType, data)
-	job.Dispatch(ctx, t)
-	return t.Wait(time.Second * 5)
+	select {
+	case <-time.After(5 * time.Second):
+		return &wasm.EventHandleResult{
+			InstanceID: i.id.String(),
+			Code:       wasm.ResultStatusCode_Failed,
+			ErrMsg:     "fail to add the event to the VM",
+		}
+	case i.msgQueue <- newTask(ctx, fn, eventType, data):
+		return &wasm.EventHandleResult{
+			InstanceID: i.id.String(),
+			Code:       wasm.ResultStatusCode_OK,
+			ErrMsg:     "",
+		}
+	}
 }
 
-func (i *Instance) Handle(ctx context.Context, t *Task) *wasm.EventHandleResult {
+func (i *Instance) queueWorker() {
+	for {
+		task, more := <-i.msgQueue
+		if !more {
+			return
+		}
+		res := i.handle(task.ctx, task)
+		if len(res.ErrMsg) > 0 {
+			job.Dispatch(i.ctx, job.NewWasmLogTask(i.ctx, conflog.Level(log.ErrorLevel).String(), "vmTask", res.ErrMsg))
+		} else {
+			job.Dispatch(i.ctx, job.NewWasmLogTask(
+				i.ctx,
+				conflog.Level(log.InfoLevel).String(),
+				"vmTask",
+				fmt.Sprintf("the event, whose eventtype is %s, is successfully handled by %s, ", task.EventType, task.Handler),
+			))
+		}
+	}
+}
+
+func (i *Instance) handle(ctx context.Context, task *Task) *wasm.EventHandleResult {
 	l := types.MustLoggerFromContext(ctx)
 
 	_, l = l.Start(ctx, "instance.Handle")
 	defer l.End()
 
-	rid := i.AddResource(ctx, []byte(t.EventType), t.Payload)
+	rid := i.AddResource(ctx, []byte(task.EventType), task.Payload)
 	defer i.RmvResource(ctx, rid)
 
 	if err := i.rt.Instantiate(); err != nil {
@@ -110,7 +155,7 @@ func (i *Instance) Handle(ctx context.Context, t *Task) *wasm.EventHandleResult 
 	defer i.rt.Deinstantiate()
 
 	// TODO support wasm return data(not only code) for HTTP responding
-	result, err := i.rt.Call(t.Handler, int32(rid))
+	result, err := i.rt.Call(task.Handler, int32(rid))
 	if err != nil {
 		l.Error(err)
 		return &wasm.EventHandleResult{
@@ -126,11 +171,8 @@ func (i *Instance) Handle(ctx context.Context, t *Task) *wasm.EventHandleResult 
 	}
 }
 
-const MaxUint = ^uint32(0)
-const MaxInt = int(MaxUint >> 1)
-
 func (i *Instance) AddResource(ctx context.Context, eventType, data []byte) uint32 {
-	var id = int32(uuid.New().ID() % uint32(MaxInt))
+	var id = int32(uuid.New().ID() % uint32(maxInt))
 	i.res.Store(uint32(id), data)
 	i.evs.Store(uint32(id), eventType)
 	return uint32(id)
@@ -143,12 +185,4 @@ func (i *Instance) GetResource(id uint32) ([]byte, bool) {
 func (i *Instance) RmvResource(ctx context.Context, id uint32) {
 	i.res.Remove(id)
 	i.evs.Remove(id)
-}
-
-func (i *Instance) Get(k string) int32 {
-	data, _ := i.kvs.Get(k)
-	var ret int32
-	buf := bytes.NewBuffer(data)
-	binary.Read(buf, binary.LittleEndian, &ret)
-	return ret
 }

--- a/pkg/modules/vm/wasmtime/instance.go
+++ b/pkg/modules/vm/wasmtime/instance.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	maxUint           = ^uint32(0)
-	maxInt            = int(maxUint >> 1)
+	maxUint = ^uint32(0)
+	maxInt  = int(maxUint >> 1)
+	// TODO: add into config
 	maxMsgPerInstance = 5000
 )
 

--- a/pkg/modules/vm/wasmtime/instance_runtime.go
+++ b/pkg/modules/vm/wasmtime/instance_runtime.go
@@ -3,7 +3,7 @@ package wasmtime
 import (
 	"encoding/binary"
 
-	"github.com/bytecodealliance/wasmtime-go"
+	"github.com/bytecodealliance/wasmtime-go/v8"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/modules/vm/wasmtime/task.go
+++ b/pkg/modules/vm/wasmtime/task.go
@@ -2,9 +2,6 @@ package wasmtime
 
 import (
 	"context"
-	"time"
-
-	"github.com/machinefi/w3bstream/pkg/types/wasm"
 )
 
 func newTask(ctx context.Context, fn string, eventType string, data []byte) *Task {
@@ -22,39 +19,8 @@ type Task struct {
 	EventType string
 	Handler   string
 	Payload   []byte
-	// mq.TaskState
-}
-
-// var _ mq.Task = (*Task)(nil)
-
-func (t *Task) Subject() string {
-	return "HandleEvent"
-}
-
-func (t *Task) Arg() interface{} {
-	return t
-}
-
-func (t *Task) Wait(du time.Duration) *wasm.EventHandleResult {
-	panic("deprecated")
-	// select {
-	// case <-time.After(du):
-	// 	return &wasm.EventHandleResult{
-	// 		InstanceID: t.vm.ID(),
-	// 		Rsp:        nil,
-	// 		Code:       -1,
-	// 		ErrMsg:     "handle timeout",
-	// 	}
-	// case ret := <-t.Res:
-	// 	return ret
-	// }
-}
-
-func (t *Task) ID() string {
-	panic("deprecated")
-	// return fmt.Sprintf("%s::%s::%s", t.Subject(), t.vm.ID(), t.EventID)
 }
 
 func (t *Task) Handle(ctx context.Context) {
-	// t.Res <- t.vm.Handle(ctx, t)
+	panic("deprecated")
 }

--- a/pkg/modules/vm/wasmtime/task.go
+++ b/pkg/modules/vm/wasmtime/task.go
@@ -2,33 +2,30 @@ package wasmtime
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"github.com/machinefi/w3bstream/pkg/depends/kit/mq"
 	"github.com/machinefi/w3bstream/pkg/types/wasm"
 )
 
-func NewTask(vm *Instance, fn string, eventType string, pl []byte) *Task {
+func newTask(ctx context.Context, fn string, eventType string, data []byte) *Task {
 	return &Task{
-		vm:      vm,
-		Handler: fn,
-		Payload: pl,
-		Res:     make(chan *wasm.EventHandleResult, 1),
+		ctx:       ctx,
+		EventType: eventType,
+		Handler:   fn,
+		Payload:   data,
 	}
 }
 
 type Task struct {
-	vm        *Instance
+	ctx       context.Context
 	EventID   string
 	EventType string
 	Handler   string
 	Payload   []byte
-	Res       chan *wasm.EventHandleResult
-	mq.TaskState
+	// mq.TaskState
 }
 
-var _ mq.Task = (*Task)(nil)
+// var _ mq.Task = (*Task)(nil)
 
 func (t *Task) Subject() string {
 	return "HandleEvent"
@@ -39,23 +36,25 @@ func (t *Task) Arg() interface{} {
 }
 
 func (t *Task) Wait(du time.Duration) *wasm.EventHandleResult {
-	select {
-	case <-time.After(du):
-		return &wasm.EventHandleResult{
-			InstanceID: t.vm.ID(),
-			Rsp:        nil,
-			Code:       -1,
-			ErrMsg:     "handle timeout",
-		}
-	case ret := <-t.Res:
-		return ret
-	}
+	panic("deprecated")
+	// select {
+	// case <-time.After(du):
+	// 	return &wasm.EventHandleResult{
+	// 		InstanceID: t.vm.ID(),
+	// 		Rsp:        nil,
+	// 		Code:       -1,
+	// 		ErrMsg:     "handle timeout",
+	// 	}
+	// case ret := <-t.Res:
+	// 	return ret
+	// }
 }
 
 func (t *Task) ID() string {
-	return fmt.Sprintf("%s::%s::%s", t.Subject(), t.vm.ID(), t.EventID)
+	panic("deprecated")
+	// return fmt.Sprintf("%s::%s::%s", t.Subject(), t.vm.ID(), t.EventID)
 }
 
 func (t *Task) Handle(ctx context.Context) {
-	t.Res <- t.vm.Handle(ctx, t)
+	// t.Res <- t.vm.Handle(ctx, t)
 }


### PR DESCRIPTION
The multi threads panic under the high load
> thread '<unnamed>' panicked at 'object used with the wrong store', crates/wasmtime/src/store/data.rs:258:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
SIGABRT: abort
PC=0x7f698972bce1 m=7 sigcode=18446744073709551610

Other changes in the pr:
 - Upgrade wasmtime from v1 to v8 without changing interfaces
 - Limit one consumer to handle the event for each instance. The `maxMsgPerInstance` is limited to 5k
 - The result is responded once the event is inserted into the queue or timeout
