### PR TITLE
fix(event): fix event type strategy

### DIFF
--- a/pkg/models/strategy.go
+++ b/pkg/models/strategy.go
@@ -9,7 +9,7 @@ import (
 // Strategy event route strategy
 // @def primary                       ID
 // @def unique_index UI_strategy_id   StrategyID
-// @def unique_index UI_prj_app_event ProjectID AppletID EventType Handler
+// @def unique_index UI_prj_app_event ProjectID AppletID EventType
 //
 //go:generate toolkit gen model Strategy --database DB
 type Strategy struct {

--- a/pkg/models/strategy__generated.go
+++ b/pkg/models/strategy__generated.go
@@ -61,7 +61,6 @@ func (m *Strategy) IndexFieldNames() []string {
 	return []string{
 		"AppletID",
 		"EventType",
-		"Handler",
 		"ID",
 		"ProjectID",
 		"StrategyID",
@@ -74,7 +73,6 @@ func (*Strategy) UniqueIndexes() builder.Indexes {
 			"ProjectID",
 			"AppletID",
 			"EventType",
-			"Handler",
 			"DeletedAt",
 		},
 		"ui_strategy_id": []string{
@@ -238,7 +236,7 @@ func (m *Strategy) FetchByID(db sqlx.DBExecutor) error {
 	return err
 }
 
-func (m *Strategy) FetchByProjectIDAndAppletIDAndEventTypeAndHandler(db sqlx.DBExecutor) error {
+func (m *Strategy) FetchByProjectIDAndAppletIDAndEventType(db sqlx.DBExecutor) error {
 	tbl := db.T(m)
 	err := db.QueryAndScan(
 		builder.Select(nil).
@@ -249,11 +247,10 @@ func (m *Strategy) FetchByProjectIDAndAppletIDAndEventTypeAndHandler(db sqlx.DBE
 						tbl.ColByFieldName("ProjectID").Eq(m.ProjectID),
 						tbl.ColByFieldName("AppletID").Eq(m.AppletID),
 						tbl.ColByFieldName("EventType").Eq(m.EventType),
-						tbl.ColByFieldName("Handler").Eq(m.Handler),
 						tbl.ColByFieldName("DeletedAt").Eq(m.DeletedAt),
 					),
 				),
-				builder.Comment("Strategy.FetchByProjectIDAndAppletIDAndEventTypeAndHandler"),
+				builder.Comment("Strategy.FetchByProjectIDAndAppletIDAndEventType"),
 			),
 		m,
 	)
@@ -310,7 +307,7 @@ func (m *Strategy) UpdateByID(db sqlx.DBExecutor, zeros ...string) error {
 	return m.UpdateByIDWithFVs(db, fvs)
 }
 
-func (m *Strategy) UpdateByProjectIDAndAppletIDAndEventTypeAndHandlerWithFVs(db sqlx.DBExecutor, fvs builder.FieldValues) error {
+func (m *Strategy) UpdateByProjectIDAndAppletIDAndEventTypeWithFVs(db sqlx.DBExecutor, fvs builder.FieldValues) error {
 
 	if _, ok := fvs["UpdatedAt"]; !ok {
 		fvs["UpdatedAt"] = types.Timestamp{Time: time.Now()}
@@ -323,10 +320,9 @@ func (m *Strategy) UpdateByProjectIDAndAppletIDAndEventTypeAndHandlerWithFVs(db 
 					tbl.ColByFieldName("ProjectID").Eq(m.ProjectID),
 					tbl.ColByFieldName("AppletID").Eq(m.AppletID),
 					tbl.ColByFieldName("EventType").Eq(m.EventType),
-					tbl.ColByFieldName("Handler").Eq(m.Handler),
 					tbl.ColByFieldName("DeletedAt").Eq(m.DeletedAt),
 				),
-				builder.Comment("Strategy.UpdateByProjectIDAndAppletIDAndEventTypeAndHandlerWithFVs"),
+				builder.Comment("Strategy.UpdateByProjectIDAndAppletIDAndEventTypeWithFVs"),
 			).
 			Set(tbl.AssignmentsByFieldValues(fvs)...),
 	)
@@ -334,14 +330,14 @@ func (m *Strategy) UpdateByProjectIDAndAppletIDAndEventTypeAndHandlerWithFVs(db 
 		return err
 	}
 	if affected, _ := res.RowsAffected(); affected == 0 {
-		return m.FetchByProjectIDAndAppletIDAndEventTypeAndHandler(db)
+		return m.FetchByProjectIDAndAppletIDAndEventType(db)
 	}
 	return nil
 }
 
-func (m *Strategy) UpdateByProjectIDAndAppletIDAndEventTypeAndHandler(db sqlx.DBExecutor, zeros ...string) error {
+func (m *Strategy) UpdateByProjectIDAndAppletIDAndEventType(db sqlx.DBExecutor, zeros ...string) error {
 	fvs := builder.FieldValueFromStructByNoneZero(m, zeros...)
-	return m.UpdateByProjectIDAndAppletIDAndEventTypeAndHandlerWithFVs(db, fvs)
+	return m.UpdateByProjectIDAndAppletIDAndEventTypeWithFVs(db, fvs)
 }
 
 func (m *Strategy) UpdateByStrategyIDWithFVs(db sqlx.DBExecutor, fvs builder.FieldValues) error {
@@ -430,7 +426,7 @@ func (m *Strategy) SoftDeleteByID(db sqlx.DBExecutor) error {
 	return err
 }
 
-func (m *Strategy) DeleteByProjectIDAndAppletIDAndEventTypeAndHandler(db sqlx.DBExecutor) error {
+func (m *Strategy) DeleteByProjectIDAndAppletIDAndEventType(db sqlx.DBExecutor) error {
 	tbl := db.T(m)
 	_, err := db.Exec(
 		builder.Delete().
@@ -441,17 +437,16 @@ func (m *Strategy) DeleteByProjectIDAndAppletIDAndEventTypeAndHandler(db sqlx.DB
 						tbl.ColByFieldName("ProjectID").Eq(m.ProjectID),
 						tbl.ColByFieldName("AppletID").Eq(m.AppletID),
 						tbl.ColByFieldName("EventType").Eq(m.EventType),
-						tbl.ColByFieldName("Handler").Eq(m.Handler),
 						tbl.ColByFieldName("DeletedAt").Eq(m.DeletedAt),
 					),
 				),
-				builder.Comment("Strategy.DeleteByProjectIDAndAppletIDAndEventTypeAndHandler"),
+				builder.Comment("Strategy.DeleteByProjectIDAndAppletIDAndEventType"),
 			),
 	)
 	return err
 }
 
-func (m *Strategy) SoftDeleteByProjectIDAndAppletIDAndEventTypeAndHandler(db sqlx.DBExecutor) error {
+func (m *Strategy) SoftDeleteByProjectIDAndAppletIDAndEventType(db sqlx.DBExecutor) error {
 	tbl := db.T(m)
 	fvs := builder.FieldValues{}
 
@@ -469,10 +464,9 @@ func (m *Strategy) SoftDeleteByProjectIDAndAppletIDAndEventTypeAndHandler(db sql
 					tbl.ColByFieldName("ProjectID").Eq(m.ProjectID),
 					tbl.ColByFieldName("AppletID").Eq(m.AppletID),
 					tbl.ColByFieldName("EventType").Eq(m.EventType),
-					tbl.ColByFieldName("Handler").Eq(m.Handler),
 					tbl.ColByFieldName("DeletedAt").Eq(m.DeletedAt),
 				),
-				builder.Comment("Strategy.SoftDeleteByProjectIDAndAppletIDAndEventTypeAndHandler"),
+				builder.Comment("Strategy.SoftDeleteByProjectIDAndAppletIDAndEventType"),
 			).
 			Set(tbl.AssignmentsByFieldValues(fvs)...),
 	)

--- a/pkg/modules/strategy/strategy.go
+++ b/pkg/modules/strategy/strategy.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"github.com/machinefi/w3bstream/pkg/enums"
 
 	confid "github.com/machinefi/w3bstream/pkg/depends/conf/id"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx"
@@ -245,6 +246,15 @@ func FilterByProjectAndEvent(ctx context.Context, id types.SFID, tpe string) ([]
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(data) == 0 {
+		data, err = ListDetailByCond(ctx, &CondArgs{
+			ProjectID: id, EventTypes: []string{enums.EVENTTYPEDEFAULT}},
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	results := make([]*types.StrategyResult, 0, len(data))

--- a/pkg/modules/strategy/strategy.go
+++ b/pkg/modules/strategy/strategy.go
@@ -3,11 +3,11 @@ package strategy
 import (
 	"context"
 	"fmt"
-	"github.com/machinefi/w3bstream/pkg/enums"
 
 	confid "github.com/machinefi/w3bstream/pkg/depends/conf/id"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx/builder"
+	"github.com/machinefi/w3bstream/pkg/enums"
 	"github.com/machinefi/w3bstream/pkg/errors/status"
 	"github.com/machinefi/w3bstream/pkg/models"
 	"github.com/machinefi/w3bstream/pkg/types"


### PR DESCRIPTION
#578 
1. An eventType can only correspond to one handler
2. A handler can be triggered by more than one eventType
3. If the eventType has a corresponding handler, only the corresponding handler will be triggered, not the default handler.
4. If eventType does not have a corresponding handler, use default handler