### PR TITLE
Clean metrics when project is removed

### DIFF
--- a/cmd/srv-applet-mgr/apis/event/pos.go
+++ b/cmd/srv-applet-mgr/apis/event/pos.go
@@ -7,6 +7,7 @@ import (
 	"github.com/machinefi/w3bstream/pkg/depends/kit/httptransport/httpx"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/statusx"
 	"github.com/machinefi/w3bstream/pkg/modules/event"
+	"github.com/machinefi/w3bstream/pkg/modules/metrics"
 	"github.com/machinefi/w3bstream/pkg/types"
 )
 
@@ -39,7 +40,7 @@ func (r *HandleEvent) Output(ctx context.Context) (interface{}, error) {
 	}
 
 	prj := types.MustProjectFromContext(ctx)
-	_eventMtc.WithLabelValues(prj.AccountID.String(), prj.Name, pub.Key, r.EventType).Inc()
+	metrics.EventMtc.WithLabelValues(prj.AccountID.String(), prj.Name, pub.Key, r.EventType).Inc()
 
 	ctx = types.WithEventID(ctx, r.EventID)
 	rsp.Results = event.OnEvent(ctx, r.Payload.Bytes())

--- a/cmd/srv-applet-mgr/apis/event/root.go
+++ b/cmd/srv-applet-mgr/apis/event/root.go
@@ -1,8 +1,6 @@
 package event
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/machinefi/w3bstream/pkg/depends/kit/httptransport"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/kit"
 )
@@ -11,16 +9,4 @@ var Root = kit.NewRouter(httptransport.Group("/event"))
 
 func init() {
 	Root.Register(kit.NewRouter(&HandleEvent{}))
-}
-
-var _eventMtc = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "inbound_events_metrics",
-		Help: "received events metrics.",
-	},
-	[]string{"account", "project", "publisher", "eventtype"},
-)
-
-func init() {
-	prometheus.MustRegister(_eventMtc)
 }

--- a/cmd/srv-applet-mgr/apis/project/del.go
+++ b/cmd/srv-applet-mgr/apis/project/del.go
@@ -3,8 +3,6 @@ package project
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/machinefi/w3bstream/cmd/srv-applet-mgr/apis/middleware"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/httptransport/httpx"
 	"github.com/machinefi/w3bstream/pkg/modules/blockchain"
@@ -25,20 +23,14 @@ func (r *RemoveProject) Output(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 	// TODO @zhiran  move this to bff request
-	var errRM error
 	if err := blockchain.RemoveMonitor(ctx, name); err != nil {
-		errRM = errors.Wrap(err, errRM.Error())
-		l := types.MustLoggerFromContext(ctx)
-		l.Error(err)
+		return nil, err
 	}
 
-	metrics.RemoveMetrics(ctx, acc.AccountID.String(), name)
-
-	if err := project.RemoveBySFID(ctx, types.MustProjectFromContext(ctx).ProjectID); err != nil {
-		errRM = errors.Wrap(err, errRM.Error())
-		l := types.MustLoggerFromContext(ctx)
-		l.Error(err)
+	if err := metrics.RemoveMetrics(ctx, acc.AccountID.String(), name); err != nil {
+		return nil, err
 	}
 
-	return nil, errRM
+	v := types.MustProjectFromContext(ctx)
+	return nil, project.RemoveBySFID(ctx, v.ProjectID)
 }

--- a/cmd/srv-applet-mgr/apis/project/del.go
+++ b/cmd/srv-applet-mgr/apis/project/del.go
@@ -6,6 +6,7 @@ import (
 	"github.com/machinefi/w3bstream/cmd/srv-applet-mgr/apis/middleware"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/httptransport/httpx"
 	"github.com/machinefi/w3bstream/pkg/modules/blockchain"
+	"github.com/machinefi/w3bstream/pkg/modules/metrics"
 	"github.com/machinefi/w3bstream/pkg/modules/project"
 	"github.com/machinefi/w3bstream/pkg/types"
 )
@@ -16,13 +17,17 @@ type RemoveProject struct {
 
 func (r *RemoveProject) Output(ctx context.Context) (interface{}, error) {
 	name := middleware.MustProjectName(ctx)
-	ctx, err := middleware.MustCurrentAccountFromContext(ctx).
-		WithProjectContextByName(ctx, name)
+	acc := middleware.MustCurrentAccountFromContext(ctx)
+	ctx, err := acc.WithProjectContextByName(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 	// TODO @zhiran  move this to bff request
 	if err := blockchain.RemoveMonitor(ctx, name); err != nil {
+		return nil, err
+	}
+
+	if err := metrics.RemoveMetrics(ctx, acc.AccountID.String(), name); err != nil {
 		return nil, err
 	}
 

--- a/cmd/srv-applet-mgr/apis/project/del.go
+++ b/cmd/srv-applet-mgr/apis/project/del.go
@@ -23,13 +23,12 @@ func (r *RemoveProject) Output(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 	// TODO @zhiran  move this to bff request
+	// TODO: del op should be BASE among async modules
 	if err := blockchain.RemoveMonitor(ctx, name); err != nil {
 		return nil, err
 	}
 
-	if err := metrics.RemoveMetrics(ctx, acc.AccountID.String(), name); err != nil {
-		return nil, err
-	}
+	metrics.RemoveMetrics(ctx, acc.AccountID.String(), name)
 
 	v := types.MustProjectFromContext(ctx)
 	return nil, project.RemoveBySFID(ctx, v.ProjectID)

--- a/cmd/srv-applet-mgr/config/config.yml.template
+++ b/cmd/srv-applet-mgr/config/config.yml.template
@@ -17,6 +17,7 @@ SRV_APPLET_MGR__Logger_Level: debug
 SRV_APPLET_MGR__Logger_Name: srv-applet-mgr
 SRV_APPLET_MGR__Logger_Output: ALWAYS
 SRV_APPLET_MGR__Logger_ReportCaller: "false"
+SRV_APPLET_MGR__MetricsCenter_Endpoint: ""
 SRV_APPLET_MGR__MonitorDB_ConnMaxLifetime: 1h
 SRV_APPLET_MGR__MonitorDB_Master: postgres://127.0.0.1:5432
 SRV_APPLET_MGR__MonitorDB_PoolSize: "10"

--- a/cmd/srv-applet-mgr/global/config.go
+++ b/cmd/srv-applet-mgr/global/config.go
@@ -55,39 +55,41 @@ func init() {
 	// TODO config struct should be defined outside this method and impl it's Init() interface{}
 	// TODO split this init too long
 	config := &struct {
-		Postgres     *confpostgres.Endpoint
-		MonitorDB    *confpostgres.Endpoint
-		WasmDB       *base.Endpoint
-		MqttBroker   *confmqtt.Broker
-		Redis        *confredis.Redis
-		Server       *confhttp.Server
-		Jwt          *confjwt.Jwt
-		Logger       *conflog.Log
-		UploadConf   *types.UploadConfig
-		EthClient    *types.ETHClientConfig
-		WhiteList    *types.WhiteList
-		ServerEvent  *confhttp.Server
-		FileSystem   *types.FileSystem
-		AmazonS3     *amazonS3.AmazonS3
-		LocalFS      *local.LocalFileSystem
-		WasmDBConfig *types.WasmDBConfig
+		Postgres      *confpostgres.Endpoint
+		MonitorDB     *confpostgres.Endpoint
+		WasmDB        *base.Endpoint
+		MqttBroker    *confmqtt.Broker
+		Redis         *confredis.Redis
+		Server        *confhttp.Server
+		Jwt           *confjwt.Jwt
+		Logger        *conflog.Log
+		UploadConf    *types.UploadConfig
+		EthClient     *types.ETHClientConfig
+		WhiteList     *types.WhiteList
+		ServerEvent   *confhttp.Server
+		FileSystem    *types.FileSystem
+		AmazonS3      *amazonS3.AmazonS3
+		LocalFS       *local.LocalFileSystem
+		WasmDBConfig  *types.WasmDBConfig
+		MetricsCenter *types.MetricsCenterConfig
 	}{
-		Postgres:     db,
-		MonitorDB:    monitordb,
-		WasmDB:       wasmdb,
-		MqttBroker:   &confmqtt.Broker{},
-		Redis:        &confredis.Redis{},
-		Server:       ServerMgr,
-		Jwt:          &confjwt.Jwt{},
-		Logger:       &conflog.Log{},
-		UploadConf:   &types.UploadConfig{},
-		EthClient:    &types.ETHClientConfig{},
-		WhiteList:    &types.WhiteList{},
-		ServerEvent:  ServerEvent,
-		FileSystem:   &types.FileSystem{},
-		AmazonS3:     &amazonS3.AmazonS3{},
-		LocalFS:      &local.LocalFileSystem{},
-		WasmDBConfig: &types.WasmDBConfig{},
+		Postgres:      db,
+		MonitorDB:     monitordb,
+		WasmDB:        wasmdb,
+		MqttBroker:    &confmqtt.Broker{},
+		Redis:         &confredis.Redis{},
+		Server:        ServerMgr,
+		Jwt:           &confjwt.Jwt{},
+		Logger:        &conflog.Log{},
+		UploadConf:    &types.UploadConfig{},
+		EthClient:     &types.ETHClientConfig{},
+		WhiteList:     &types.WhiteList{},
+		ServerEvent:   ServerEvent,
+		FileSystem:    &types.FileSystem{},
+		AmazonS3:      &amazonS3.AmazonS3{},
+		LocalFS:       &local.LocalFileSystem{},
+		WasmDBConfig:  &types.WasmDBConfig{},
+		MetricsCenter: &types.MetricsCenterConfig{},
 	}
 
 	name := os.Getenv(consts.EnvProjectName)
@@ -142,6 +144,7 @@ func init() {
 		types.WithFileSystemOpContext(fs),
 		types.WithProxyClientContext(proxy),
 		types.WithWasmDBConfigContext(config.WasmDBConfig),
+		types.WithMetricsCenterConfigContext(config.MetricsCenter),
 	)
 	Context = WithContext(context.Background())
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       SRV_APPLET_MGR__MonitorDB_PoolSize: 5
       SRV_APPLET_MGR__WasmDB: postgresql://${POSTGRES_USER:-w3badmin}:${POSTGRES_PASSWORD:-PaSsW0Rd}@postgres:5432
       SRV_APPLET_MGR__MqttBroker_Server: mqtt://mqtt_server:1883
+      SRV_APPLET_MGR__MetricsCenter_Endpoint: http://prometheus:9090
       SRV_APPLET_MGR__Server_Port: "8888"
       SRV_APPLET_MGR__ServerEvent_Port: "8889"
       SRV_APPLET_MGR__LocalFS_Root: /w3bstream/asserts
@@ -69,14 +70,14 @@ services:
       - '6379:6379'
 
   prometheus:
-    image: imoocc/prometheus:latest
+    image: prom/prometheus:latest
     depends_on:
       - "w3bapp"
     user: root
-    command: --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml
+    command: --web.enable-lifecycle --web.enable-admin-api --config.file=/etc/prometheus/prometheus.yml
     container_name: prometheus
     restart: always
     volumes:
-      - ${WS_WORKING_DIR:-.}/prometheus:/prometheus
+      - ./build/var/prometheus/conf/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"

--- a/pkg/modules/metrics/metrics.go
+++ b/pkg/modules/metrics/metrics.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/machinefi/w3bstream/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	_eventMtcName        = "inbound_events_metrics"
+	_publisherMtcName    = "publishers_metrics"
+	_blockChainTxMtcName = "w3b_blockchain_tx_metrics"
+)
+
+var (
+	EventMtc = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: _eventMtcName,
+			Help: "received events metrics.",
+		},
+		[]string{"account", "project", "publisher", "eventtype"},
+	)
+
+	PublisherMtc = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: _publisherMtcName,
+			Help: "registered publishers for the project.",
+		},
+		[]string{"account", "project"},
+	)
+
+	BlockChainTxMtc = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: _blockChainTxMtcName,
+		Help: "blockchain transaction counter metrics.",
+	}, []string{"project", "chainID"})
+)
+
+func init() {
+	prometheus.MustRegister(EventMtc)
+	prometheus.MustRegister(PublisherMtc)
+	prometheus.MustRegister(BlockChainTxMtc)
+}
+
+func RemoveMetrics(ctx context.Context, account string, project string) error {
+	EventMtc.DeletePartialMatch(prometheus.Labels{"account": account, "project": project})
+	PublisherMtc.DeletePartialMatch(prometheus.Labels{"account": account, "project": project})
+	BlockChainTxMtc.DeletePartialMatch(prometheus.Labels{"project": project})
+
+	if err := eraseDataInServer(ctx, account, project); err != nil {
+		l := types.MustLoggerFromContext(ctx)
+		// the metrics server isn't essential for the core service
+		l.Warn(err)
+	}
+	return nil
+}
+
+func eraseDataInServer(ctx context.Context, account string, project string) error {
+	cfg, existed := types.MetricsCenterConfigFromContext(ctx)
+	if !existed {
+		return errors.New("fail to get the url of metrics center")
+	}
+	baseURL := cfg.Endpoint
+
+	if err := httpReq(
+		fmt.Sprintf("%s/api/v1/admin/tsdb/delete_series?match[]=%s",
+			baseURL,
+			url.QueryEscape(fmt.Sprintf(`%s{account="%s", project="%s"}`, _eventMtcName, account, project))),
+	); err != nil {
+		return err
+	}
+
+	if err := httpReq(
+		fmt.Sprintf("%s/api/v1/admin/tsdb/delete_series?match[]=%s",
+			baseURL,
+			url.QueryEscape(fmt.Sprintf(`%s{account="%s", project="%s"}`, _publisherMtcName, account, project))),
+	); err != nil {
+		return err
+	}
+
+	if err := httpReq(
+		fmt.Sprintf("%s/api/v1/admin/tsdb/delete_series?match[]=%s",
+			baseURL,
+			url.QueryEscape(fmt.Sprintf(`%s{project="%s"}`, _blockChainTxMtcName, project))),
+	); err != nil {
+		return err
+	}
+	return cleanTombstones(baseURL)
+}
+
+func cleanTombstones(baseURL string) error {
+	return httpReq(fmt.Sprintf("%s/api/v1/admin/tsdb/clean_tombstones", baseURL))
+}
+
+func httpReq(url string) error {
+	// Create the HTTP client and request
+	client := http.Client{}
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return err
+	}
+
+	// Send the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return errors.New("the http request to metrics center fails")
+	}
+
+	return nil
+}

--- a/pkg/modules/metrics/metrics.go
+++ b/pkg/modules/metrics/metrics.go
@@ -46,7 +46,7 @@ func init() {
 	prometheus.MustRegister(BlockChainTxMtc)
 }
 
-func RemoveMetrics(ctx context.Context, account string, project string) error {
+func RemoveMetrics(ctx context.Context, account string, project string) {
 	EventMtc.DeletePartialMatch(prometheus.Labels{"account": account, "project": project})
 	PublisherMtc.DeletePartialMatch(prometheus.Labels{"account": account, "project": project})
 	BlockChainTxMtc.DeletePartialMatch(prometheus.Labels{"project": project})
@@ -56,7 +56,6 @@ func RemoveMetrics(ctx context.Context, account string, project string) error {
 		// the metrics server isn't essential for the core service
 		l.Warn(err)
 	}
-	return nil
 }
 
 func eraseDataInServer(ctx context.Context, account string, project string) error {

--- a/pkg/modules/metrics/metrics.go
+++ b/pkg/modules/metrics/metrics.go
@@ -46,7 +46,7 @@ func init() {
 	prometheus.MustRegister(BlockChainTxMtc)
 }
 
-func RemoveMetrics(ctx context.Context, account string, project string) {
+func RemoveMetrics(ctx context.Context, account string, project string) error {
 	EventMtc.DeletePartialMatch(prometheus.Labels{"account": account, "project": project})
 	PublisherMtc.DeletePartialMatch(prometheus.Labels{"account": account, "project": project})
 	BlockChainTxMtc.DeletePartialMatch(prometheus.Labels{"project": project})
@@ -56,6 +56,7 @@ func RemoveMetrics(ctx context.Context, account string, project string) {
 		// the metrics server isn't essential for the core service
 		l.Warn(err)
 	}
+	return nil
 }
 
 func eraseDataInServer(ctx context.Context, account string, project string) error {

--- a/pkg/modules/publisher/publisher.go
+++ b/pkg/modules/publisher/publisher.go
@@ -3,28 +3,15 @@ package publisher
 import (
 	"context"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	confid "github.com/machinefi/w3bstream/pkg/depends/conf/id"
 	confjwt "github.com/machinefi/w3bstream/pkg/depends/conf/jwt"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/sqlx/builder"
 	"github.com/machinefi/w3bstream/pkg/errors/status"
 	"github.com/machinefi/w3bstream/pkg/models"
+	"github.com/machinefi/w3bstream/pkg/modules/metrics"
 	"github.com/machinefi/w3bstream/pkg/types"
 )
-
-var _publisherMtc = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Name: "publishers_metrics",
-		Help: "registered publishers for the project.",
-	},
-	[]string{"account", "project"},
-)
-
-func init() {
-	prometheus.MustRegister(_publisherMtc)
-}
 
 func GetBySFID(ctx context.Context, id types.SFID) (*models.Publisher, error) {
 	d := types.MustMgrDBExecutorFromContext(ctx)
@@ -149,7 +136,7 @@ func RemoveBySFID(ctx context.Context, acc *models.Account, prj *models.Project,
 	).Do(); err != nil {
 		return err
 	}
-	_publisherMtc.WithLabelValues(acc.AccountID.String(), prj.Name).Dec()
+	metrics.PublisherMtc.WithLabelValues(acc.AccountID.String(), prj.Name).Dec()
 	return nil
 }
 
@@ -188,7 +175,7 @@ func Remove(ctx context.Context, acc *models.Account, r *CondArgs) error {
 	if err != nil {
 		return err
 	}
-	_publisherMtc.WithLabelValues(acc.AccountID.String(), prj.Name).Sub(float64(numDeleted))
+	metrics.PublisherMtc.WithLabelValues(acc.AccountID.String(), prj.Name).Sub(float64(numDeleted))
 	return nil
 }
 
@@ -217,7 +204,7 @@ func Create(ctx context.Context, acc *models.Account, prj *models.Project, r *Cr
 		}
 		return nil, status.DatabaseError.StatusErr().WithDesc(err.Error())
 	}
-	_publisherMtc.WithLabelValues(acc.AccountID.String(), prj.Name).Inc()
+	metrics.PublisherMtc.WithLabelValues(acc.AccountID.String(), prj.Name).Inc()
 	return pub, nil
 }
 

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -17,36 +17,37 @@ import (
 )
 
 type (
-	CtxMgrDBExecutor     struct{} // CtxMgrDBExecutor sqlx.DBExecutor
-	CtxMonitorDBExecutor struct{} // CtxMonitorDBExecutor sqlx.DBExecutor
-	CtxWasmDBEndpoint    struct{} // CtxWasmDBEndpoint sqlx.DBExecutor
-	CtxLogger            struct{} // CtxLogger log.Logger
-	CtxMqttBroker        struct{} // CtxMqttBroker mqtt.Broker
-	CtxRedisEndpoint     struct{} // CtxRedisEndpoint redis.Redis
-	CtxUploadConfig      struct{} // CtxUploadConfig UploadConfig
-	CtxTaskWorker        struct{}
-	CtxTaskBoard         struct{}
-	CtxProject           struct{}
-	CtxApplet            struct{}
-	CtxResource          struct{}
-	CtxInstance          struct{}
-	CtxEthClient         struct{} // CtxEthClient ETHClientConfig
-	CtxWhiteList         struct{}
-	CtxFileSystem        struct{}
-	CtxStrategy          struct{}
-	CtxPublisher         struct{}
-	CtxCronJob           struct{}
-	CtxOperator          struct{}
-	ContractLog          struct{}
-	ChainHeight          struct{}
-	ChainTx              struct{}
-	CtxAccount           struct{}
-	CtxStrategyResults   struct{}
-	CtxFileSystemOp      struct{}
-	CtxProxyClient       struct{}
-	CtxResourceOwnership struct{}
-	CtxWasmDBConfig      struct{} // CtxWasmDBConfig wasm database config
-	CtxEventID           struct{}
+	CtxMgrDBExecutor       struct{} // CtxMgrDBExecutor sqlx.DBExecutor
+	CtxMonitorDBExecutor   struct{} // CtxMonitorDBExecutor sqlx.DBExecutor
+	CtxWasmDBEndpoint      struct{} // CtxWasmDBEndpoint sqlx.DBExecutor
+	CtxLogger              struct{} // CtxLogger log.Logger
+	CtxMqttBroker          struct{} // CtxMqttBroker mqtt.Broker
+	CtxRedisEndpoint       struct{} // CtxRedisEndpoint redis.Redis
+	CtxUploadConfig        struct{} // CtxUploadConfig UploadConfig
+	CtxTaskWorker          struct{}
+	CtxTaskBoard           struct{}
+	CtxProject             struct{}
+	CtxApplet              struct{}
+	CtxResource            struct{}
+	CtxInstance            struct{}
+	CtxEthClient           struct{} // CtxEthClient ETHClientConfig
+	CtxWhiteList           struct{}
+	CtxFileSystem          struct{}
+	CtxStrategy            struct{}
+	CtxPublisher           struct{}
+	CtxCronJob             struct{}
+	CtxOperator            struct{}
+	ContractLog            struct{}
+	ChainHeight            struct{}
+	ChainTx                struct{}
+	CtxAccount             struct{}
+	CtxStrategyResults     struct{}
+	CtxFileSystemOp        struct{}
+	CtxProxyClient         struct{}
+	CtxResourceOwnership   struct{}
+	CtxWasmDBConfig        struct{} // CtxWasmDBConfig wasm database config
+	CtxEventID             struct{}
+	CtxMetricsCenterConfig struct{}
 )
 
 func WithStrategyResults(ctx context.Context, v []*StrategyResult) context.Context {
@@ -658,6 +659,27 @@ func EventIDFromContext(ctx context.Context) (string, bool) {
 
 func MustEventIDFromContext(ctx context.Context) string {
 	v, ok := EventIDFromContext(ctx)
+	must.BeTrue(ok)
+	return v
+}
+
+func WithMetricsCenterConfig(ctx context.Context, v *MetricsCenterConfig) context.Context {
+	return contextx.WithValue(ctx, CtxMetricsCenterConfig{}, v)
+}
+
+func WithMetricsCenterConfigContext(v *MetricsCenterConfig) contextx.WithContext {
+	return func(ctx context.Context) context.Context {
+		return contextx.WithValue(ctx, CtxMetricsCenterConfig{}, v)
+	}
+}
+
+func MetricsCenterConfigFromContext(ctx context.Context) (*MetricsCenterConfig, bool) {
+	v, ok := ctx.Value(CtxMetricsCenterConfig{}).(*MetricsCenterConfig)
+	return v, ok
+}
+
+func MustMetricsCenterConfigFromContext(ctx context.Context) *MetricsCenterConfig {
+	v, ok := MetricsCenterConfigFromContext(ctx)
 	must.BeTrue(ok)
 	return v
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -90,3 +90,7 @@ func (c *WasmDBConfig) SetDefault() {
 		c.MaxConnection = 2
 	}
 }
+
+type MetricsCenterConfig struct {
+	Endpoint string `env:""`
+}

--- a/pkg/types/wasm/wasm_config_chain_client.go
+++ b/pkg/types/wasm/wasm_config_chain_client.go
@@ -14,22 +14,13 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tidwall/gjson"
 
 	"github.com/machinefi/w3bstream/pkg/models"
+	"github.com/machinefi/w3bstream/pkg/modules/metrics"
 	"github.com/machinefi/w3bstream/pkg/modules/operator"
 	wsTypes "github.com/machinefi/w3bstream/pkg/types"
 )
-
-var _blockChainTxMtc = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Name: "w3b_blockchain_tx_metrics",
-	Help: "blockchain transaction counter metrics.",
-}, []string{"project", "chainID"})
-
-func init() {
-	prometheus.MustRegister(_blockChainTxMtc)
-}
 
 type ChainClient struct {
 	projectName string
@@ -166,7 +157,7 @@ func (c *ChainClient) sendTX(chainID uint32, toStr, valueStr, dataStr string, pv
 		return "", err
 	}
 
-	_blockChainTxMtc.WithLabelValues(c.projectName, strconv.Itoa(int(chainID))).Inc()
+	metrics.BlockChainTxMtc.WithLabelValues(c.projectName, strconv.Itoa(int(chainID))).Inc()
 
 	err = cli.SendTransaction(context.Background(), signedTx)
 	if err != nil {
@@ -210,7 +201,7 @@ func (c *ChainClient) CallContract(chainID uint32, toStr, dataStr string) ([]byt
 		Data: data,
 	}
 
-	_blockChainTxMtc.WithLabelValues(c.projectName, strconv.Itoa(int(chainID))).Inc()
+	metrics.BlockChainTxMtc.WithLabelValues(c.projectName, strconv.Itoa(int(chainID))).Inc()
 
 	return cli.CallContract(context.Background(), msg, nil)
 }


### PR DESCRIPTION
the changes include:
1. All global metrics are moved to `./pkg/modules/metrics/metrics.go`
2. `RemoveMetrics()` is invoked when the project is deleted
3. `SRV_APPLET_MGR__MetricsCenter_Endpoint` is added into `docker-compose.yaml` to configure the endpoint of Prometheus server