### PR TITLE
chore(ci): use macos matrix.os as macos-latest-x1

### DIFF
--- a/.github/workflows/build_and_post_docker_image.yml
+++ b/.github/workflows/build_and_post_docker_image.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest-x1]
     permissions:
       contents: read
       packages: write
@@ -41,7 +41,7 @@ jobs:
 
       # Docker is not installed by default on macos base image for license reason : https://github.com/actions/runner-images/issues/17
       - name: Setup Docker and Colima
-        if: startsWith(matrix.os, 'macos-latest') == true
+        if: startsWith(matrix.os, 'macos-latest-x1') == true
         run: |
           brew install docker colima
           colima start

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest-x1]
     permissions:
       contents: read
       packages: write
@@ -38,7 +38,7 @@ jobs:
 
       # Docker is not installed by default on macos base image for license reason : https://github.com/actions/runner-images/issues/17
       - name: Setup Docker and Colima
-        if: startsWith(matrix.os, 'macos-latest') == true
+        if: startsWith(matrix.os, 'macos-latest-x1') == true
         run: |
           brew install docker colima
           colima start

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           - os: windows-latest
             artifact_name: pub_client-windows-amd64.exe
             applet_mgr_name: srv-applet-mgr-windows-amd64
-          - os: macos-latest
+          - os: macos-latest-x1
             artifact_name: pub_client-darwin-amd64
             applet_mgr_name: srv-applet-mgr-darwin-amd64
 


### PR DESCRIPTION
Reason: https://github.blog/2023-03-01-github-actions-introducing-faster-github-hosted-x64-macos-runners/