### PR TITLE
chore(ci): use 'scratch' image as runtime to trim image size

### DIFF
--- a/cmd/srv-applet-mgr/Dockerfile
+++ b/cmd/srv-applet-mgr/Dockerfile
@@ -21,12 +21,11 @@ COPY ./ ./
 RUN make build
 
 # runtime
-FROM golang:1.19 AS runtime
+FROM scratch AS runtime
 
 COPY --from=builder /go/src/build/srv-applet-mgr/srv-applet-mgr /go/bin/srv-applet-mgr
 COPY --from=builder /go/src/build/srv-applet-mgr/openapi.json /go/bin/openapi.json
 EXPOSE 8888
 
 WORKDIR /go/bin
-RUN echo $PATH
 ENTRYPOINT ["/go/bin/srv-applet-mgr"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,6 @@ services:
     container_name: prometheus
     restart: always
     volumes:
-      - ./build/var/prometheus/conf/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ${WS_WORKING_DIR:-.}/prometheus/conf/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"


### PR DESCRIPTION
Fix docker-compose.yml