### PR TITLE
chore: trim docker image size

### DIFF
--- a/cmd/srv-applet-mgr/Dockerfile
+++ b/cmd/srv-applet-mgr/Dockerfile
@@ -16,15 +16,21 @@ FROM golang:1.19 AS builder
 WORKDIR /go/src
 COPY ./ ./
 
+RUN apt install make
+
 # build
 #ARG COMMIT_SHA
 RUN cd ./cmd/srv-applet-mgr && make target
+RUN mkdir -p build/srv-applet-mgr/lib
+RUN ldd build/srv-applet-mgr/srv-applet-mgr | tr -s '[:blank:]' '\n' | grep '^/' | xargs -I % sh -c 'cp % build/srv-applet-mgr/lib/'
+RUN ldd `which go` | tr -s '[:blank:]' '\n' | grep '^/' | xargs -I % sh -c 'cp % build/srv-applet-mgr/lib/'
 
 # runtime
-FROM golang:1.19 AS runtime
+FROM scratch AS runtime
 
 COPY --from=builder /go/src/build/srv-applet-mgr/srv-applet-mgr /go/bin/srv-applet-mgr
 COPY --from=builder /go/src/build/srv-applet-mgr/openapi.json /go/bin/openapi.json
+COPY --from=builder /go/src/build/lib /
 EXPOSE 8888
 
 WORKDIR /go/bin

--- a/cmd/srv-applet-mgr/Makefile
+++ b/cmd/srv-applet-mgr/Makefile
@@ -20,7 +20,7 @@ openapi: toolkit
 
 .PHONY: build
 build: clean
-	@go build -ldflags "-X ${VERSION_PATH}.Name=srv-applet-mgr\
+	@go build -ldflags "-s -w -X ${VERSION_PATH}.Name=srv-applet-mgr\
  -X ${VERSION_PATH}.Feature=${FEATURE}\
  -X ${VERSION_PATH}.Version=${VERSION}\
  -X ${VERSION_PATH}.Timestamp=${BUILD_TIME}"


### PR DESCRIPTION
Try to copy runtime and dynamical libraries to `scratch` for building a minimal golang runtime image