### PR TITLE
Integrate Server push into route `/event`

### DIFF
--- a/cmd/srv-applet-mgr/apis/event/pos.go
+++ b/cmd/srv-applet-mgr/apis/event/pos.go
@@ -33,7 +33,7 @@ func (r *HandleEvent) Path() string {
 func (r *HandleEvent) Output(ctx context.Context) (interface{}, error) {
 	r.EventReq.SetDefault()
 
-	if r.IsBatched() {
+	if r.IsDataPush() {
 		return handleDataPush(ctx, r.Channel, r.Payload.Bytes())
 	}
 

--- a/cmd/srv-applet-mgr/apis/event/root.go
+++ b/cmd/srv-applet-mgr/apis/event/root.go
@@ -6,13 +6,10 @@ import (
 	"github.com/machinefi/w3bstream/pkg/depends/kit/kit"
 )
 
-// TODO: Unify the event interface
 var (
-	Root  = kit.NewRouter(httptransport.Group("/event"), &middleware.EventReqRateLimit{})
-	Root2 = kit.NewRouter(httptransport.Group("/event2"), &middleware.EventReqRateLimit{})
+	Root = kit.NewRouter(httptransport.Group("/event"), &middleware.EventReqRateLimit{})
 )
 
 func init() {
 	Root.Register(kit.NewRouter(&HandleEvent{}))
-	Root2.Register(kit.NewRouter(&HandleDataPush{}))
 }

--- a/cmd/srv-applet-mgr/apis/middleware/current_publisher.go
+++ b/cmd/srv-applet-mgr/apis/middleware/current_publisher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/machinefi/w3bstream/pkg/depends/conf/jwt"
 	"github.com/machinefi/w3bstream/pkg/depends/kit/httptransport/httpx"
 	"github.com/machinefi/w3bstream/pkg/depends/x/misc/must"
+	"github.com/machinefi/w3bstream/pkg/enums"
 	"github.com/machinefi/w3bstream/pkg/errors/status"
 	"github.com/machinefi/w3bstream/pkg/models"
 	"github.com/machinefi/w3bstream/pkg/modules/account"
@@ -25,7 +26,7 @@ var ctxPublisherAuthKey = reflect.TypeOf(ContextAccountAuth{}).String()
 func (r *ContextPublisherAuth) ContextKey() string { return ctxPublisherAuthKey }
 
 func (r *ContextPublisherAuth) Output(ctx context.Context) (interface{}, error) {
-	content, err := jwt.AuthContentFromContext(ctx)
+	content, idType, err := jwt.AuthContentFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -33,6 +34,13 @@ func (r *ContextPublisherAuth) Output(ctx context.Context) (interface{}, error) 
 	id := types.SFID(0)
 	if err := id.UnmarshalText(content); err != nil {
 		return nil, status.InvalidAuthPublisherID
+	}
+	if idType == enums.ACCESS_KEY_IDENTITY_TYPE__ACCOUNT {
+		ca, err := account.GetAccountByAccountID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		return &CurrentAccount{*ca}, nil
 	}
 	cp, err := publisher.GetBySFID(ctx, id)
 	if err != nil {

--- a/cmd/srv-applet-mgr/apis/middleware/current_user.go
+++ b/cmd/srv-applet-mgr/apis/middleware/current_user.go
@@ -34,7 +34,7 @@ var contextAccountAuthKey = reflect.TypeOf(ContextAccountAuth{}).String()
 func (r *ContextAccountAuth) ContextKey() string { return contextAccountAuthKey }
 
 func (r *ContextAccountAuth) Output(ctx context.Context) (interface{}, error) {
-	content, err := jwt.AuthContentFromContext(ctx)
+	content, _, err := jwt.AuthContentFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/srv-applet-mgr/apis/root.go
+++ b/cmd/srv-applet-mgr/apis/root.go
@@ -68,7 +68,6 @@ func init() {
 		auth.Register(operator.Root)
 		auth.Register(traffic_limit.Root)
 		auth.Register(projectoperator.Root)
-		auth.Register(event.Root2)
 	}
 
 	// root router register for event http transport

--- a/pkg/depends/conf/jwt/jwt_auth.go
+++ b/pkg/depends/conf/jwt/jwt_auth.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/machinefi/w3bstream/pkg/depends/x/contextx"
 	"github.com/machinefi/w3bstream/pkg/depends/x/misc/must"
+	"github.com/machinefi/w3bstream/pkg/enums"
 	"github.com/machinefi/w3bstream/pkg/errors/status"
+	"github.com/machinefi/w3bstream/pkg/models"
 )
 
 type Auth struct {
@@ -78,7 +80,7 @@ func AuthFromContext(ctx context.Context) interface{} {
 	return ctx.Value(keyAuth{})
 }
 
-func AuthContentFromContext(ctx context.Context) (content []byte, err error) {
+func AuthContentFromContext(ctx context.Context) (content []byte, ty enums.AccessKeyIdentityType, err error) {
 	switch v := AuthFromContext(ctx).(type) {
 	case []byte:
 		content = v
@@ -86,6 +88,9 @@ func AuthContentFromContext(ctx context.Context) (content []byte, err error) {
 		content = []byte(v)
 	case fmt.Stringer:
 		content = []byte(v.String())
+	case *models.AccessKey:
+		content = []byte(v.IdentityID.String())
+		ty = v.IdentityType
 	default:
 		err = status.InvalidAuthValue
 	}

--- a/pkg/modules/access_key/access_key.go
+++ b/pkg/modules/access_key/access_key.go
@@ -201,5 +201,5 @@ func Validate(ctx context.Context, key string) (interface{}, error, bool) {
 	}
 
 	// TODO check privileges
-	return m.IdentityID, nil, true
+	return m, nil, true
 }

--- a/pkg/modules/access_key/zz_access_key_test.go
+++ b/pkg/modules/access_key/zz_access_key_test.go
@@ -303,9 +303,9 @@ func TestAccessKey(t *testing.T) {
 			NewWithT(t).Expect(canBeValidated).To(BeTrue())
 			NewWithT(t).Expect(err).To(BeNil())
 
-			idVal, ok := idAny.(types.SFID)
+			idVal, ok := idAny.(*models.AccessKey)
 			NewWithT(t).Expect(ok).To(BeTrue())
-			NewWithT(t).Expect(idVal).To(Equal(id))
+			NewWithT(t).Expect(idVal.IdentityID).To(Equal(id))
 		})
 		t.Run("#Failed", func(t *testing.T) {
 			t.Run("#AccessKeyContextUnmarshalFailed", func(t *testing.T) {

--- a/pkg/modules/event/event_models.go
+++ b/pkg/modules/event/event_models.go
@@ -10,6 +10,10 @@ import (
 	"github.com/machinefi/w3bstream/pkg/types"
 )
 
+const (
+	EVENTTYPEBATCHED = "EVENT_BATCHED"
+)
+
 type EventReq struct {
 	// Channel message channel named (intact project name)
 	Channel string `in:"path"  name:"channel"`
@@ -21,8 +25,6 @@ type EventReq struct {
 	Timestamp int64 `in:"query" name:"timestamp,omitempty"`
 	// Payload event payload (binary only)
 	Payload bytes.Buffer `in:"body" mime:"stream"`
-	// TODO: Remove DeviceID
-	DeviceID string `in:"query" name:"device_id,omitempty"`
 }
 
 func (r *EventReq) SetDefault() {
@@ -35,6 +37,10 @@ func (r *EventReq) SetDefault() {
 	if r.Timestamp == 0 {
 		r.Timestamp = time.Now().UTC().Unix()
 	}
+}
+
+func (r *EventReq) IsBatched() bool {
+	return r.EventType == EVENTTYPEBATCHED
 }
 
 type Result struct {

--- a/pkg/modules/event/event_models.go
+++ b/pkg/modules/event/event_models.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	EVENTTYPEBATCHED = "EVENT_BATCHED"
+	eventTypeDataPush = "$DATA#PUSH"
 )
 
 type EventReq struct {
@@ -39,8 +39,8 @@ func (r *EventReq) SetDefault() {
 	}
 }
 
-func (r *EventReq) IsBatched() bool {
-	return r.EventType == EVENTTYPEBATCHED
+func (r *EventReq) IsDataPush() bool {
+	return r.EventType == eventTypeDataPush
 }
 
 type Result struct {

--- a/pkg/modules/event/event_models.go
+++ b/pkg/modules/event/event_models.go
@@ -21,6 +21,8 @@ type EventReq struct {
 	Timestamp int64 `in:"query" name:"timestamp,omitempty"`
 	// Payload event payload (binary only)
 	Payload bytes.Buffer `in:"body" mime:"stream"`
+	// TODO: Remove DeviceID
+	DeviceID string `in:"query" name:"device_id,omitempty"`
 }
 
 func (r *EventReq) SetDefault() {


### PR DESCRIPTION
1. Support server push in `/event` route
2. Support batched event via EventType
3. Deprecated `/event2` route